### PR TITLE
Added support for changing the default API URL for Github Enterprise installations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,8 @@ github.post "gists", data, (gist) ->
   console.log gist.url
 ```
 
+If `process.env.HUBOT_GITHUB_URL` exists, it will override the default API URL. This is useful for Enterprise Github installations
+
 ## Authentication ##
 
 If `process.env.HUBOT_GITHUB_TOKEN` is present, you're automatically authenticated. Sweet!

--- a/githubot.coffee
+++ b/githubot.coffee
@@ -17,9 +17,13 @@ class Github
   request: (verb, url, data, cb) ->
     unless cb?
       [cb, data] = [data, null]
+
+    unless (url_api_base = process.env.HUBOT_GITHUB_URL)?
+      url_api_base = "https://api.github.com"
+
     if url[0..3] isnt "http"
       url = "/#{url}" unless url[0] is "/"
-      url = "https://api.github.com#{url}"
+      url = "#{url_api_base}#{url}"
     req = http.create(url).header("Accept", "application/vnd.github.beta+json")
     req = req.header("Authorization", "token #{oauth_token}") if (oauth_token = process.env.HUBOT_GITHUB_TOKEN)?
     req[verb.toLowerCase()](JSON.stringify data) (err, res, body) =>


### PR DESCRIPTION
This makes use of the HUBOT_GITHUB_URL variable to override the default API location. If the variable doesn't exist, it defaults to https://api.github.com/
