### PR TITLE
Add commit formatting (optional oneline and gitio reduction)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "scoped-http-client": ">= 0.9.8",
-    "async": "0.2.x"
+    "async": "0.2.x",
+    "gitio2": ">= 2.0.0"
   },
   "devDependencies": {
     "mocha": "1.x",

--- a/src/commits.coffee
+++ b/src/commits.coffee
@@ -1,0 +1,40 @@
+gitio = require "gitio2"
+
+module.exports = (repo, commit, cb) ->
+  if cb?
+    if commit?
+      @get "repos/#{@qualified_repo repo}/commits/#{commit}", cb
+    else
+      @get "repos/#{@qualified_repo repo}/commits", cb
+  else
+    format: (commit, cb) =>
+      if @_opt "oneline"
+        if commit.message?
+          commit.message = commit.message.split("\n")[0]
+        else if commit.commit? and commit.commit.message?
+          commit.message = commit.commit.message.split("\n")[0]
+      else if commit.commit? and commit.commit.message? and not commit.message?
+        commit.message = commit.commit.message
+      if not commit.html_url?
+        regex = new RegExp "^#{@_opt "apiRoot"}/(api/#{@_opt "apiVersion"}/)?repos/([^/]+)/([^/]+)/(?:git/)?commits/([a-f0-9]+)$"
+        match = commit.url.match regex
+        if match?
+          api = match[1]
+          owner = match[2]
+          repo = match[3]
+          sha = match[4]
+          if api?
+            base_url = @_opt "apiRoot"
+          else
+            base_url = "https://github.com"
+          commit.html_url = "#{base_url}/#{owner}/#{repo}/commit/#{sha}"
+        else
+          console.log "Unmatched commit URL: #{commit.url}"
+          commit.html_url = commit.url
+      if @_opt "gitio"
+        gitio commit.html_url, (err, data) ->
+          if not err
+            commit.html_url = data
+            cb commit
+      else
+        cb commit

--- a/src/githubot.coffee
+++ b/src/githubot.coffee
@@ -101,6 +101,8 @@ class Github
 
   branches: require './branches'
 
+  commits: require './commits'
+
   deployments: require './deployments'
 
   _opt: (optName) ->
@@ -120,6 +122,10 @@ class Github
         process.env.HUBOT_GITHUB_API ? "https://api.github.com"
       when "apiVersion"
         process.env.HUBOT_GITHUB_API_VERSION ? "v3"
+      when "gitio"
+        process.env.HUBOT_GITIO
+      when "oneline"
+        process.env.HUBOT_COMMIT_ONELINE
       else null
 
 module.exports = github = (robot, options = {}) ->

--- a/test/commits.coffee
+++ b/test/commits.coffee
@@ -1,0 +1,42 @@
+[ gh, assert, nock, mock_robot ] = require "./test_helper"
+
+describe "commit utilities", ->
+  describe "formatting", ->
+    summary = "message summary"
+    commit =
+      sha: "abcdeg"
+      url: "https://github.com/foo/bar/commit/abcdeg"
+      message: summary + "\n\nmessage body"
+    gitio_short = "yyy"
+    gitio_url = "http://git.io/" + gitio_short
+    network = null
+    success = (done) ->
+      network.done()
+      done()
+    it "formats commits with gitio", (done) ->
+      network = nock("http://git.io")
+        .post("/create")
+        .reply(201, gitio_short)
+      gh.withOptions(
+        gitio: true
+        )
+        .commits().format commit, (commit) ->
+          assert.deepEqual commit.html_url, gitio_url
+          success done
+    it "formats commits without gitio", (done) ->
+      original_url = commit.html_url
+      gh.commits().format commit, (commit) ->
+        assert.deepEqual commit.html_url, original_url
+        done()
+    it "formats commits with oneline", (done) ->
+      gh.withOptions(
+        oneline: true
+        )
+        .commits().format commit, (commit) ->
+          assert.deepEqual commit.message, summary
+          done()
+    it "formats commits without oneline", (done) ->
+      original_message = commit.message
+      gh.commits().format commit, (commit) ->
+        assert.deepEqual commit.message, original_message
+        done()


### PR DESCRIPTION
I'd like to centralize commit formatting between Hubot scripts, and
this seemed like an appropriate place.  I've stubbed this out, but the
tests are currently failing and I haven't had time to track down the
reasons yet (assistance welcome!).  Once this gets fixed up and
released, we can use it in github/hubot-scripts#1461.
