### PR TITLE
Add license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Hubot-compatible Github API wrapper for Node.js",
   "version": "1.0.0",
   "homepage": "https://github.com/iangreenleaf/githubot",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:iangreenleaf/githubot.git"


### PR DESCRIPTION
Installing local node modules raises the following warning : `npm WARN githubot@1.0.0 No license field.`

Adding a license field with a valid SPDX license expression fixes the warning.